### PR TITLE
change ranking_position to nullable on users

### DIFF
--- a/db/migrate/20180615101911_change_ranking_position_to_nullable_on_user.rb
+++ b/db/migrate/20180615101911_change_ranking_position_to_nullable_on_user.rb
@@ -1,0 +1,9 @@
+class ChangeRankingPositionToNullableOnUser < ActiveRecord::Migration[5.2]
+  def up
+    change_column :users, :ranking_position, :integer, null: true, default: nil
+  end
+
+  def down
+    change_column :users, :ranking_position, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_31_162330) do
+ActiveRecord::Schema.define(version: 2018_06_15_101911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -106,7 +106,7 @@ ActiveRecord::Schema.define(version: 2018_05_31_162330) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
-    t.integer "ranking_position", default: 0, null: false
+    t.integer "ranking_position"
     t.string "deactivation_token", null: false
     t.datetime "deactivated_at"
     t.integer "points_match_average"

--- a/test/services/update_users_rankings_service_test.rb
+++ b/test/services/update_users_rankings_service_test.rb
@@ -5,7 +5,7 @@ class UpdateUsersRankingsServiceTest < ActiveSupport::TestCase
     service = UpdateUsersRankingsService.new
     user = users(:diego)
 
-    assert_changes 'user.ranking_position', from: 0, to: 1 do
+    assert_changes 'user.ranking_position', from: nil, to: 1 do
       service.run!
       user.reload
     end


### PR DESCRIPTION
Bug

When Tournament has started and new users register they get initially `ranking_position: 0` which puts them at the top of the global scores ranking