### PR TITLE
ignore matches in the past when showing "unpredicted matches"

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -18,6 +18,7 @@ class Match < ApplicationRecord
     where.not(left_team_score: nil)
       .where.not(right_team_score: nil)
   }
+  scope :upcoming, -> { where('kickoff_at > ?', Time.zone.now) }
 
   validates_presence_of :phase, :left_team, :right_team, :venue, :kickoff_at
   validate :right_team_is_not_same_as_left_team

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,7 +33,7 @@ class User < ApplicationRecord
   end
 
   def unpredicted_matches
-    Match.where.not(id: self.predictions.pluck(:match_id))
+    Match.upcoming.where.not(id: self.predictions.pluck(:match_id))
   end
 
   def deactivate!

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -83,3 +83,10 @@ kubi:
   nickname: 'Kubi'
   deactivation_token: 'kubi_deactivation_token'
   points_total: 10
+
+roberto:
+  <<: *DEFAULTS
+  email: 'roberto@dev.tippkick.club'
+  player_id: 'roberto-baggio-90001'
+  nickname: 'Roberto'
+  deactivation_token: 'roberto_deactivation_token'

--- a/test/integration/users_flows_test.rb
+++ b/test/integration/users_flows_test.rb
@@ -53,6 +53,24 @@ class UsersFlowsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'user sees no missing predictions after world cup' do
+    user = users(:roberto)
+
+    assert_equal 0, user.predictions.count, 'Roberto should not have any predicions at all for this test'
+
+    sign_in user
+
+    travel_to before_the_world_cup do
+      get authenticated_root_path
+      assert_select '.unpredicted_matches', { count: 1 }, 'Should see unpredicted matches before the world cup'
+    end
+
+    travel_to after_the_world_cup do
+      get authenticated_root_path
+      assert_select '.unpredicted_matches', { count: 0 }, 'Should NOT see unpredicted matches after the world cup'
+    end
+  end
+
   test 'koebi sees his ranking in squad overview' do
     koebi = users(:koebi)
 

--- a/test/models/match_test.rb
+++ b/test/models/match_test.rb
@@ -1,4 +1,14 @@
 require 'test_helper'
 
 class MatchTest < ActiveSupport::TestCase
+  test 'upcoming scope' do
+    travel_to before_the_world_cup do
+      assert_equal 5, Match.upcoming.count
+    end
+
+    first_match = Match.ordered.first
+    travel_to first_match.kickoff_at do
+      assert_equal 4, Match.upcoming.count
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,10 @@ class ActiveSupport::TestCase
   def during_the_world_cup
     Time.new(2018, 6, 30, 0, 0, 0, 0)
   end
+
+  def after_the_world_cup
+    Time.new(2019, 1, 1, 0, 0, 0, 0)
+  end
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
fixes #124 